### PR TITLE
retrieve completed tsks based on batches

### DIFF
--- a/src/scale_result_parser.py
+++ b/src/scale_result_parser.py
@@ -34,7 +34,8 @@ def main(cfg, args):
 
     while (True):
         tasks = client.tasks(
-            start_time=(now - timedelta(days=args.ago)).strftime("%Y-%m-%d"),
+            batch=args.project,
+            status='completed',
             next_token=next_token,
             project=cfg.get("CommonAccountKeys", 'ScaleAccountName'),
         )
@@ -98,8 +99,6 @@ if __name__ == '__main__':
         "--project", help="Name of the batch to club results by", required=True)
     parser.add_argument(
         "--cfg", help="Configuration file, see master.cfg", required=True)
-    parser.add_argument(
-        "--ago", help="Number of days ago to start the search from", default=1, type=int)
 
     # check input arguments
     args = parser.parse_args()

--- a/src/scale_result_parser.py
+++ b/src/scale_result_parser.py
@@ -51,10 +51,6 @@ def main(cfg, args):
     rater_stats = []
 
     for task in all_tasks:
-        # Filter out results that are not a part of the interested project
-        if task.param_dict['metadata']['group'] != args.project:
-            continue
-
         for file_url in task.param_dict['metadata']['file_urls']:
             clip_dict = {
                 'short_file_name': task.param_dict['metadata']['file_shortname']}


### PR DESCRIPTION
1. Retrieve scale tasks based on project name instead of based on `created_at` time. (this will only work fror tasks created after [this PR](https://github.com/microsoft/P.808/pull/45) was merged)
2. Add filter parameter on retrieve tasks function to only retrieve "completed" tasks from scale. 