### PR TITLE
add reference url support to scale ratings

### DIFF
--- a/src/scale_audio_rating.py
+++ b/src/scale_audio_rating.py
@@ -201,7 +201,10 @@ async def prepare_metadata_per_task(cfg, clips, gold, trapping, output_dir):
         metadata['file_urls'] = {}
         for col in df_clips.columns:
             if df_clips.loc[df_clips.index[i], col] != '':
-                metadata['file_urls'][col] = df_clips.loc[df_clips.index[i], col]
+                if col == 'reference':
+                    metadata['reference_url'] = df_clips.loc[df_clips.index[i], col]
+                else:
+                    metadata['file_urls'][col] = df_clips.loc[df_clips.index[i], col]
         metadata['ground_truth'] = []
         random_gold_sample = df_gold.sample()
         random_trap_sample = df_trap.sample()


### PR DESCRIPTION
Add reference audio support to scale rating uploads.
This change will only take effect on P835-DNC tasks on Scale's end. 

1. To support this change the config file will need to be updated to target the new `ScaleAccountName`
2. The new format for the expected input to support a reference file will be a column added to the CSV called "reference" that will provide the target reference audio file per row. 