### PR TITLE
Adds session token to boto3 client creation.

### DIFF
--- a/src/configurations/mturk.cfg
+++ b/src/configurations/mturk.cfg
@@ -3,6 +3,7 @@
 [general]
 aws_access_key_id: YOUR_AWS_ACCESS_KEY_ID
 aws_secret_access_key: YOUR_AWS_SECRET_ACCESS_KEY
+aws_session_token: YOUR_AWS_SESSION_TOKEN
 # default values for MTurk
 region_name: us-east-1
 # end point for the production system system

--- a/src/mturk_utils.py
+++ b/src/mturk_utils.py
@@ -663,6 +663,7 @@ if __name__ == '__main__':
         region_name=mturk_general['region_name'],
         aws_access_key_id=mturk_general['aws_access_key_id'],
         aws_secret_access_key=mturk_general['aws_secret_access_key'],
+        aws_session_token=mturk_general['aws_session_token'],
         )
 
     if args.send_emails is not None:


### PR DESCRIPTION
I was unable to get my credentials to validate without the session token. I have used this in the past without it, so perhaps this is a recent requirement.