### PR TITLE
Fix #54: add HIT limit acknowledgement checkbox

### DIFF
--- a/src/P808Template/ACR_template.html
+++ b/src/P808Template/ACR_template.html
@@ -1120,6 +1120,7 @@ function generate_rating_section(){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 
 				  <h3>Attention: </h3>
 				  <p>This hit includes one or more Control clips (gold clips). Control clips are ones that we know that answer for and should be very easy to rate (they are clearly very good or very poor). They may target one or more scales. We include control clips in the HIT to ensure raters are paying attention and their environment hasn't changed.

--- a/src/P808Template/CCR_template.html
+++ b/src/P808Template/CCR_template.html
@@ -1344,6 +1344,7 @@ function generate_rating_section(){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			
 				  <h3>Attention: </h3>
 				  <p>This hit includes one or more Control clips (gold clips). Control clips are ones that we know that answer for and should be very easy to rate (they are clearly very good or very poor). We include control clips in the HIT to ensure raters are paying attention and their environment hasn't changed.

--- a/src/P808Template/DCR_template.html
+++ b/src/P808Template/DCR_template.html
@@ -1050,6 +1050,7 @@ function generate_rating_section(){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 				  <h3>Attention: </h3>
 				  <p>This hit includes one or more Control clips (gold clips). Control clips are ones that we know that answer for and should be very easy to rate (they are clearly very good or very poor). We include control clips in the HIT to ensure raters are paying attention and their environment hasn't changed.
 					  Wrong answer to control clip(s) will result in rejection of the HIT.</p>

--- a/src/P808Template/P808_multi.html
+++ b/src/P808Template/P808_multi.html
@@ -2690,6 +2690,7 @@ function preventTabsChangeBeforeRateRating(){
 				<p>Bonuses will be assigned with in 7 days.</p>
 				<b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than
 					that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 
 				<h3>Attention: </h3>
 				<p>This hit includes one or more Control clips (gold clips). Control clips are ones that we know that answer for and should be very easy to rate (they are clearly very good or very poor). They may target one or more scales. We include control clips in the HIT to ensure raters are paying attention and their environment hasn't changed.

--- a/src/P808Template/P831_ACR_template.html
+++ b/src/P808Template/P831_ACR_template.html
@@ -1054,6 +1054,7 @@ function generate_rating_section(){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			</div>
 		</div>
 

--- a/src/P808Template/P831_DCR_template.html
+++ b/src/P808Template/P831_DCR_template.html
@@ -985,6 +985,7 @@ function generate_rating_section(){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			</div>
 		</div>
 

--- a/src/P808Template/P835_personalized_template3.html
+++ b/src/P808Template/P835_personalized_template3.html
@@ -1827,6 +1827,7 @@
 				<p>Bonuses will be assigned with in 7 days.</p>
 				<b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than
 					that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 
 				<h3>Attention: </h3>
 				<p>This hit includes one or more Control clips (gold clips). Control clips are ones that we know that answer for and should be very easy to rate (they are clearly very good or very poor). They may target one or more scales. We include control clips in the HIT to ensure raters are paying attention and their environment hasn't changed.

--- a/src/P808Template/P835_template.html
+++ b/src/P808Template/P835_template.html
@@ -1336,6 +1336,7 @@ function questionName2Text(qName){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			</div>
 		</div>
 

--- a/src/P808Template/P835_template_one_audio.html
+++ b/src/P808Template/P835_template_one_audio.html
@@ -1196,6 +1196,7 @@ function questionName2Text(qName){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			</div>
 		</div>
 

--- a/src/P808Template/bw_check.html
+++ b/src/P808Template/bw_check.html
@@ -2051,6 +2051,7 @@
 				<p>Bonuses will be assigned with in 7 days.</p>
 				<b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than
 					that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			</div>
 		</div>
 

--- a/src/P808Template/echo_impairment_test_fest_template.html
+++ b/src/P808Template/echo_impairment_test_fest_template.html
@@ -1271,6 +1271,7 @@ function questionName2Text(qName){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			</div>
 		</div>
 

--- a/src/P808Template/echo_impairment_test_template.html
+++ b/src/P808Template/echo_impairment_test_template.html
@@ -1279,6 +1279,7 @@ function questionName2Text(qName){
 
 				<p>Bonuses will be assigned with in 7 days.</p>
 				  <b>Please perform up to <b class="max_allowed_hits"> 0 </b> HITs from this group. If you do more than that, the <u>rest will be rejected.</u></b>
+<div class="checkbox"><label><input type="checkbox" name="ack_limit" required> I understand that I will only be paid for up to <b class="max_allowed_hits"> 0 </b> HITs.</label></div>
 			</div>
 		</div>
 


### PR DESCRIPTION
## Summary
- add a required checkbox acknowledging the max HIT limit in all HTML templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840baa1d4488328a91a24e9df0001a8