### PR TITLE
Document Azure blob storage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ If you use this tool in your research please cite it with the following referenc
 * [Preparation](docs/preparation.md)
 * [Running the Test on Amazon Mechanical Turk](docs/running_test_mturk.md)
 * [Analyzing Data](docs/results.md)
+* [Azure Blob Storage Support](docs/azure_support.md)
+
+By default the scripts expect CSV files listing the clip URLs.  When the optional
+Azure configuration is provided and the CSV arguments are omitted, the toolkit
+will download clip lists from an Azure Blob Storage container.
 
 
 ## News

--- a/docs/azure_support.md
+++ b/docs/azure_support.md
@@ -1,0 +1,31 @@
+[Home](../README.md) > Azure Blob Storage Support
+# Azure Blob Storage Support
+
+The toolkit normally expects CSV files that list the URLs to all audio clips used in a test.  When a CSV file is supplied via the command line, it will be used as the data source.
+
+Alternatively, the toolkit can read audio clips directly from an Azure Blob Storage container.  To enable this, provide the storage details in the configuration file and omit the CSV arguments.
+
+## Configuration example
+```ini
+[CommonAccountKeys]
+# Storage account access key
+mystorageaccount:
+
+[DefaultStorage]
+StorageUrl:https://mystorageaccount.blob.core.windows.net
+StorageAccountKey:${CommonAccountKeys:mystorageaccount}
+Container:p808-assets
+Path:/clips/rating/
+
+[RatingClips]
+RatingClipsConfigurations:store1
+
+[store1]
+StorageUrl:${DefaultStorage:StorageUrl}
+StorageAccountKey:${DefaultStorage:StorageAccountKey}
+Container:${DefaultStorage:Container}
+Path:${DefaultStorage:Path}
+```
+
+When the above sections are present and `--clips`, `--gold_clips` and `--trapping_clips` are not supplied, the scripts will query Azure to obtain the list of clips.  Using CSV files remains the default approach and requires no Azure configuration.
+

--- a/docs/preparation.md
+++ b/docs/preparation.md
@@ -19,8 +19,11 @@ The following steps should be performed to prepare the test setup.
     pip install -r requirements.txt
     ```
     
-1. (optional) Upload the general resources (found in `src\P809Template\assets`) in a cloud server and change the 
+1. (optional) Upload the general resources (found in `src\P809Template\assets`) in a cloud server and change the
 URLs associated to them as described in [General Resources](general_res.md)
+
+1. (optional) If you want to store clips in Azure Blob Storage instead of using CSV files,
+   configure the storage details as shown in [Azure Blob Storage Support](azure_support.md).
 
 1.  Follow the rest of preparation process based on the test methodology you want to apply:
 


### PR DESCRIPTION
## Summary
- document how to store clips on Azure Blob Storage
- note that CSV files remain the default source for clip lists

## Testing
- `pre-commit run --files README.md docs/preparation.md docs/azure_support.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bd2491c883289f41ba015bc024f7