### PR TITLE
Fix path prefix handling in AzureClipStorage

### DIFF
--- a/src/azure_clip_storage.py
+++ b/src/azure_clip_storage.py
@@ -15,7 +15,10 @@ class AzureClipStorage:
         self._account_key = config['StorageAccountKey']
         self._container = config['Container']
         self._alg = alg
-        self._clips_path = config['Path'].lstrip('/')
+        path = config['Path'].lstrip('/')
+        if path and not path.endswith('/'):
+            path += '/'
+        self._clips_path = path
         self._clip_names = []
         self._modified_clip_names = []
         self._SAS_token = ''


### PR DESCRIPTION
## Summary
- fix AzureClipStorage path prefix to avoid unintended directory enumeration

## Testing
- `python -m py_compile src/azure_clip_storage.py`


------
https://chatgpt.com/codex/tasks/task_e_6840bdcacb8483288501452441c9eefd