### PR TITLE
Improve regex documentation

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -12,10 +12,15 @@ created in the first step ([preparation](preparation.md)).
     `condition_pattern` and `condition_keys`.
     
     **Note**: The `condition_pattern` specifies which part of the clip URL refers to the condition name/number that they are
-    representing. Clips with the same value on that position, are considered to belong to the same condition and votes 
-    assigned to them will be aggregated to create the `per_condition` report. Example: Assuming `D501_C03_M2_S02.wav` is 
-    a file name,and `03` is the condition name. The pattern should be set to `.*_c(?P<condition_num>\d{1,2})_.*.wav` , 
-    and the `condition_keys` to `condition_num`.
+    representing. Clips with the same value on that position, are considered to belong to the same condition and votes
+    assigned to them will be aggregated to create the `per_condition` report.
+
+    The pattern follows Python regular expression syntax and should use **named
+    capture groups**. The names of the groups become column names in the reports.
+    Example: Assuming `D501_C03_M2_S02.wav` is a file name and `03` is the
+    condition identifier, set
+    `condition_pattern: .*_c(?P<condition_num>\d{1,2})_.*\.wav` and
+    `condition_keys` to `condition_num`.
    
     **Note**: You can activate the automatic outlier detection method per condition. To do so
     open `YOUR_PROJECT_NAME_ccr_result_parser.cfg`, in section `[accept_and_use]` add `outlier_removal: true`. The [z-score


### PR DESCRIPTION
## Summary
- clarify `condition_pattern` usage in docs
- expand module docs in `result_parser.py`
- document regex extraction in `conv_filename_to_condition`

## Testing
- `python -m py_compile src/result_parser.py`
- `flake8 src/result_parser.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcd91cc483289233ce75ea1f2274