### PR TITLE
Fix bonus setting validity check

### DIFF
--- a/docs/conf_master.md
+++ b/docs/conf_master.md
@@ -34,7 +34,7 @@ following message next time they want to perform a HIT from this group:
     ````
 * `allowed_max_hit_in_project:60`: Number of assignments that one worker can perform from this project.
 * `hit_base_payment:0.5`: Base payment for an accepted assignment from this HIT. This value will be used as information.
-* `quantity_hits_more_than: 30`: Defines the necessary hits required for quantity bonus.
+* `quantity_hits_more_than: 30`: Defines the necessary hits required for quantity bonus. This should typically be about half of the total number of HITs in the study.
 * `quantity_bonus: 0.1`: The amount of the quantity bonus to be payed for each accepted assignment.
 * `quality_top_percentage: 20`: Defines when quality bonus should be applied (in addition, participant should be 
 eligible for quantity bonus).
@@ -56,7 +56,7 @@ following message next time they want to perform a HIT from this group:
     ````
 * `allowed_max_hit_in_project:60`: Number of assignments that one worker can perform from this project.
 * `hit_base_payment:0.5`: Base payment for an accepted assignment from this HIT. This value will be used as information.
-* `quantity_hits_more_than: 30`: Defines the necessary hits required for quantity bonus.
+* `quantity_hits_more_than: 30`: Defines the necessary hits required for quantity bonus. This should typically be about half of the total number of HITs in the study.
 * `quantity_bonus: 0.1`: The amount of the quantity bonus to be payed for each accepted assignment.
 * `quality_top_percentage: 20`: Defines when quality bonus should be applied (in addition, participant should be 
 eligible for quantity bonus).
@@ -75,7 +75,7 @@ following message next time they want to perform a HIT from this group:
     ````
 * `allowed_max_hit_in_project:60`: Number of assignments that one worker can perform from this project.
 * `hit_base_payment:0.5`: Base payment for an accepted assignment from this HIT. This value will be used as information.
-* `quantity_hits_more_than: 30`: Defines when quantity bonus requirement.
+* `quantity_hits_more_than: 30`: Defines when quantity bonus requirement. This should typically be about half of the total number of HITs in the study.
 * `quantity_bonus: 0.1`: the amount of the quantity bonus to be payed for each accepted assignment.
 * `quality_top_percentage: 20`: Defines when quality bonus should be applied (in addition, participant should be 
 eligible for quantity bonus).

--- a/src/master_script.py
+++ b/src/master_script.py
@@ -843,6 +843,13 @@ async def main(cfg, test_method, args):
         print("\nWARNING: it seems that 'quantity_hits_more_than' not set properly. Consider to use a number in"
                               f" the range of [{int(n_HITs/2)}, {int(n_HITs*2/3)}].\n")
 
+    # check settings of allowed hits
+    allowed_hits = int(cfg_hit_app["allowed_max_hit_in_project"])
+    if allowed_hits > n_HITs:
+        print(f"\nWARNING: 'allowed_max_hit_in_project' ({allowed_hits}) is greater than the total number of HITs ({n_HITs}).\n")
+    if allowed_hits < int(cfg_hit_app["quantity_hits_more_than"]):
+        print(f"\nWARNING: 'allowed_max_hit_in_project' ({allowed_hits}) is less than 'quantity_hits_more_than' ({cfg_hit_app['quantity_hits_more_than']}). Workers will not reach the quantity bonus.\n")
+
     # create general config
     general_cfg = prepare_basic_cfg(df)
     # add BW check config


### PR DESCRIPTION
## Summary
- warn if bonus thresholds impossible to reach
- document suggested range for `quantity_hits_more_than`

## Testing
- `python -m py_compile src/master_script.py`

------
https://chatgpt.com/codex/tasks/task_e_6840bee06bc08328adce3caacc305073