### PR TITLE
Propagate environment comparison threshold

### DIFF
--- a/src/assets_master_script/acr_result_parser_template.cfg
+++ b/src/assets_master_script/acr_result_parser_template.cfg
@@ -48,7 +48,7 @@ rejection_feedback :Answer to this assignment did not pass the quality control c
 # including acceptance_criteria
 variance_bigger_equal: 0.1
 gold_standard_bigger_equal: 1
-correct_cmp_bigger_equal: 2
+correct_cmp_bigger_equal: {{cfg.cmp_pass_threshold}}
 #outlier_removal: true
 
 [bonus]

--- a/src/assets_master_script/dcr_ccr_result_parser_template.cfg
+++ b/src/assets_master_script/dcr_ccr_result_parser_template.cfg
@@ -39,7 +39,7 @@ rejection_feedback :Answer to this assignment did not pass the quality control c
 [accept_and_use]
 # including acceptance_criteria
 variance_bigger_equal: 0.1
-correct_cmp_bigger_equal: 2
+correct_cmp_bigger_equal: {{cfg.cmp_pass_threshold}}
 #outlier_removal: true
 
 [bonus]

--- a/src/assets_master_script/p804_result_parser_template.cfg
+++ b/src/assets_master_script/p804_result_parser_template.cfg
@@ -54,7 +54,7 @@ block_rater_if_acceptance_and_used_rate_below : 20
 # including acceptance_criteria
 variance_bigger_equal: 0.1
 gold_standard_bigger_equal: 2
-correct_cmp_bigger_equal: 2
+correct_cmp_bigger_equal: {{cfg.cmp_pass_threshold}}
 outlier_removal: true
 rater_min_acceptance_rate_current_test : 50
 rater_min_accepted_hits_current_test : 1

--- a/src/assets_master_script/pp835_result_parser_template.cfg
+++ b/src/assets_master_script/pp835_result_parser_template.cfg
@@ -49,7 +49,7 @@ block_rater_if_acceptance_and_used_rate_below : 20
 # including acceptance_criteria
 variance_bigger_equal: 0.1
 gold_standard_bigger_equal: 1
-correct_cmp_bigger_equal: 2
+correct_cmp_bigger_equal: {{cfg.cmp_pass_threshold}}
 #outlier_removal: true
 rater_min_acceptance_rate_current_test : 50
 rater_min_accepted_hits_current_test : 1

--- a/src/master_script.py
+++ b/src/master_script.py
@@ -93,6 +93,7 @@ def create_analyzer_cfg_general(cfg, cfg_section, template_path, out_path, gener
     # BW check
     config['bw_min'] = general_cfg['bw_min']
     config['bw_max'] = general_cfg['bw_max']
+    config['cmp_pass_threshold'] = general_cfg['cmp_pass_threshold']
 
     with open(template_path, 'r') as file:
         content = file.read()
@@ -134,6 +135,7 @@ def create_analyzer_cfg_dcr_ccr(cfg, template_path, out_path, general_cfg, n_HIT
     # BW check
     config['bw_min'] = general_cfg['bw_min']
     config['bw_max'] = general_cfg['bw_max']
+    config['cmp_pass_threshold'] = general_cfg['cmp_pass_threshold']
     
     with open(template_path, 'r') as file:
         content = file.read()


### PR DESCRIPTION
## Summary
- use `cmp_pass_threshold` when generating analyzer cfg files
- inject `cmp_pass_threshold` placeholder in result parser templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840be1413448328b6e1fa934aa2f8ab